### PR TITLE
Address Dependabot Issues

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -15,7 +15,8 @@ on:
 jobs:
   check-dist:
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.COMMIT_PAT }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: setup git config
         run: |


### PR DESCRIPTION
Given that GITHUB_TOKEN can now get different scopes, let's see if this helps our dependabot builds.