### PR TITLE
Fix remaining usage of deprecated Node.js version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,5 +18,5 @@ inputs:
     required: true
     default: '{}'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Nodejs was upgraded from 16 to 20 in https://github.com/promiseofcake/circleci-trigger-action/pull/285 . However, one reference to Nodejs 16 exists and is creating a warning on https://github.com/promiseofcake/circleci-trigger-action/actions/runs/11899366474 .

![image](https://github.com/user-attachments/assets/57afddfb-4c79-40fb-8724-32489f1a5097)

I'm also getting a notice for a separate project that uses this workflow, even when specifically using `promiseofcake/circleci-trigger-action@v1.7.5`, so I'm hoping this change will also cause that warning to go away.

![image](https://github.com/user-attachments/assets/9b2d2bc2-67e2-48c9-9e26-4e39e6e98394)
