### PR TITLE
fix(deps): bump js-yaml 3.15.0 and brace-expansion 5.0.7 to clear open advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4260,9 +4260,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -652,9 +652,9 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2781,9 +2781,9 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.4.tgz",
-      "integrity": "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## What

Clears the remaining Dependabot advisories flagged on `main` by bumping two transitive **dev** dependencies in `package-lock.json`.

| Package | From | To | Advisory | Severity |
|---------|------|----|----------|----------|
| `js-yaml` | 3.14.2 | 3.15.0 | [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) — quadratic-complexity DoS in merge-key handling (alert #90, was **open**) | moderate |
| `brace-expansion` | 5.0.4 / 5.0.5 | 5.0.7 | [GHSA-f886-m6hf-6m8v](https://github.com/advisories/GHSA-f886-m6hf-6m8v), [GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2) — ReDoS / `max` bypass | moderate |

## Why together

`js-yaml` #90 was the last open GitHub alert. While fixing it, `npm audit` surfaced a pre-existing `brace-expansion` moderate (the two vulnerable instances nested under `eslint` and `@eslint/config-array`). Folding both into one lockfile PR.

## Notes

- Both are **transitive dev dependencies** (build/test tooling) — not part of the shipped `dist/index.js` bundle. `js-yaml` sits under `@istanbuljs/load-nyc-config` (`^3.13.1`), so no `overrides` entry is needed.
- `dist/` rebuild (`npm run prepare`) produces **no diff** — confirming neither package is bundled.
- `npm run lint` ✅, `npm test` ✅, `npm audit` → **0 vulnerabilities**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)