### PR TITLE
ci(dependabot): group updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,16 @@ updates:
     directory: /
     schedule:
       interval: daily
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: npm
     directory: /
     schedule:
       interval: daily
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
## What

Adds `groups:` to `.github/dependabot.yml` so Dependabot bundles all updates into a single PR per ecosystem:
- **npm** → one grouped PR (instead of one-per-dependency)
- **github-actions** → one grouped PR

## Why

Right now every dependency bump is its own PR, and each one needs a manual empty-commit push to get `check-dist` to rebuild `dist/` (Dependabot-triggered runs don't receive `secrets.GH_PAT`, so the auto-rebuild/push-back step can't run). Grouping collapses N manual pushes into one.

## Not addressed here

This reduces PR volume but does **not** fix the underlying `GH_PAT`-withheld-from-Dependabot issue — a grouped Dependabot PR will still need one push (or a `@dependabot rebase`) to go green. Follow-ups to consider: add `GH_PAT` to the repo's Dependabot secret store, or move `check-dist` to `pull_request_target`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)